### PR TITLE
deps: bump spring-zeebe to 8.1.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM eclipse-temurin:17.0.5_8-jre
 
 # Configure the connector runtime version
-ARG SPRING_ZEEBE_VERSION=8.1.11
+ARG SPRING_ZEEBE_VERSION=8.1.13
 
 RUN mkdir /opt/app
 # Download Spring Zeebe Connector Runtime from Maven Central


### PR DESCRIPTION
## Description

Spring Zeebe version 8.1.13 is necessary for the new patch release

