### PR TITLE
chore: moved endpoint to start.sh

### DIFF
--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -4,7 +4,12 @@ FROM eclipse-temurin:17.0.6_10-jre
 ARG SPRING_ZEEBE_VERSION=8.1.14
 
 RUN mkdir /opt/app
+
+COPY start.sh /start.sh
+RUN chmod +x start.sh
+
 # Download Spring Zeebe Connector Runtime from Maven Central
-ADD https://s01.oss.sonatype.org/content/repositories/releases/io/camunda/spring-zeebe-connector-runtime/${SPRING_ZEEBE_VERSION}/spring-zeebe-connector-runtime-${SPRING_ZEEBE_VERSION}-with-dependencies.jar /opt/app/
+ADD https://s01.oss.sonatype.org/content/repositories/releases/io/camunda/spring-zeebe-connector-runtime/${SPRING_ZEEBE_VERSION}/spring-zeebe-connector-runtime-${SPRING_ZEEBE_VERSION}-with-dependencies.jar /opt/app/runtime.jar
+
 # Use entry point to allow downstream images to add JVM arguments using CMD
-ENTRYPOINT ["java", "-cp", "/opt/app/*", "io.camunda.connector.runtime.ConnectorRuntimeApplication"]
+ENTRYPOINT ["/start.sh"]

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -44,9 +44,9 @@ docker run --rm --name=connectors -d \
            --network=your-zeebe-network \                                      # Optional: attach to network if Zeebe is isolated with Docker network
            -e ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS=ip.address.of.zeebe:26500 \  # Specify Zeebe address
            -e ZEEBE_CLIENT_SECURITY_PLAINTEXT=true \                           # Optional: provide security configs to connect to Zeebe
-           -e MY_SECRET=secret \                                               # Set a secret with value
-           -e SECRET_FROM_SHELL \                                              # Set a secret from the environment
-           --env-file secrets.txt \                                            # Set secrets from a file
+           -e MY_SECRET=secret \                                               # Optional: set a secret with value
+           -e SECRET_FROM_SHELL \                                              # Optional: set a secret from the environment
+           --env-file secrets.txt \                                            # Optional: set secrets from a file
            camunda/connectors:0.5.0
 ```
 
@@ -59,3 +59,27 @@ to inject multiple secrets at once.
 # Connectors Bundle
 
 The [Connectors Bundle project](https://github.com/camunda/connectors-bundle) contains all available out-of-the-box Connectors provided by Camunda 8.
+
+# Configuring additional JVM options
+
+In case you need to fine tune your JVM, the environment variable `JAVA_OPTS` is at your service. Just pass it through docker `-e` flag when running `docker run ...`.
+
+# Using self-signed certificates
+
+Precondition: to use self-signed certificates, you need to prepare a valid JKS [Trust Store](https://docs.oracle.com/cd/E19509-01/820-3503/6nf1il6er/index.html).
+
+You would need then to copy it into container using [Docker volumes](https://docs.docker.com/storage/volumes/), also specify container path to the trust store with `JAVAX_NET_SSL_TRUSTSTORE` environment variable, and trust store password with `JAVAX_NET_SSL_TRUSTSTOREPASSWORD` environment variable.
+
+Example:
+
+```bash
+docker run --rm --name=connectors -d \
+           -v $PWD/connector.jar:/opt/app/connector.jar \
+           -v $PWD/your_truststore_file:/opt/security/truststore/your_truststore_file \  # Mount your trust store with self-signed certificates
+           --network=your-zeebe-network \                                                # Optional: attach to network if Zeebe is isolated with Docker network
+           -e ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS=ip.address.of.zeebe:26500 \            # Specify Zeebe address
+           -e ZEEBE_CLIENT_SECURITY_PLAINTEXT=true \                                     # Optional: provide security configs to connect to Zeebe
+           -e JAVAX_NET_SSL_TRUSTSTORE=/opt/security/truststore/your_truststore_file \   # Change your trust store file name
+           -e JAVAX_NET_SSL_TRUSTSTOREPASSWORD=your_truststore_password \                # Provide your trust store password
+           camunda/connectors:0.5.0
+```

--- a/runtime/start.sh
+++ b/runtime/start.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+JAVA_OPTS="${JAVA_OPTS}"
+
+# Explicitly set trust store location
+if [[ -n "${JAVAX_NET_SSL_TRUSTSTORE}" ]]; then
+  JAVA_OPTS="${JAVA_OPTS} -Djavax.net.ssl.trustStore=${JAVAX_NET_SSL_TRUSTSTORE}"
+fi
+
+# Explicitly set trust store password
+if [[ -n "${JAVAX_NET_SSL_TRUSTSTOREPASSWORD}" ]]; then
+  JAVA_OPTS="${JAVA_OPTS} -Djavax.net.ssl.trustStorePassword=${JAVAX_NET_SSL_TRUSTSTOREPASSWORD}"
+fi
+
+if [[ -n ${DEBUG_JVM_PRINT_JAVA_OPTS} ]]; then
+  echo "Applied JVM options: $JAVA_OPTS"
+fi
+
+exec java ${JAVA_OPTS} -cp "/opt/app/*" "io.camunda.connector.runtime.ConnectorRuntimeApplication"


### PR DESCRIPTION
## Description

chore: moved endpoint to start.sh

## Related to

- https://github.com/camunda/team-connectors/issues/325

## Testing done 

Given an arbitrary generated trust store:

```
docker run --name=connectors -d \
  -v $PWD/connector.jar:/opt/app/connector.jar \
  -v /tmp/docker-runtime/trust-store/client.truststore:/opt/security/truststore/client.truststore \
  --network=camunda-platform_camunda-platform \
  -e ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS=172.19.0.3:26500 \
  -e ZEEBE_CLIENT_SECURITY_PLAINTEXT=true \
  -e JAVAX_NET_SSL_TRUSTSTORE=/opt/security/truststore/client.truststore \
  -e JAVAX_NET_SSL_TRUSTSTOREPASSWORD=password \
  camunda/connectors:0.5.0
```

