### PR TITLE
Runtime: updated README to quickstart and test runtime docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.tar.gz
 *.zip
+.idea

--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -1,5 +1,5 @@
 # Configure the connector runtime version
-ARG RUNTIME_VERSION=0.4.2
+ARG RUNTIME_VERSION=0.5.0
 FROM camunda/connectors:${RUNTIME_VERSION}
 
 # Configure versions of included connectors

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -16,15 +16,20 @@ To use the image, add at least one Connector to the classpath. We recommend prov
 Example adding a Connector JAR by extending the image
 
 ```dockerfile
-FROM camunda/connectors:0.4.2
+FROM camunda/connectors:0.5.0
 
-ADD https://repo1.maven.org/maven2/io/camunda/connector/connector-http-json/0.11.0/connector-http-json-0.11.0-with-dependencies.jar /opt/app/
+ADD https://repo1.maven.org/maven2/io/camunda/connector/connector-http-json/0.15.0/connector-http-json-0.15.0-with-dependencies.jar /opt/app/
 ```
 
 Example adding a Connector JAR by using volumes
 
 ```bash
-docker run --rm --name=connectors -d -v $PWD/connector.jar:/opt/app/ camunda/connectors:0.4.2
+docker run --rm --name=connectors -d \
+            -v $PWD/connector.jar:/opt/app/connector.jar \                      # Add a connector jar to the classpath
+            --network=your-zeebe-network \                                      # Optional: attach to network if Zeebe is isolated with Docker network
+            -e ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS=ip.address.of.zeebe:26500 \  # Specify Zeebe address
+            -e ZEEBE_CLIENT_SECURITY_PLAINTEXT=true \                           # Optional: provide security configs to connect to Zeebe
+            camunda/connectors:0.5.0
 ```
 
 # Secrets
@@ -35,11 +40,14 @@ For example, you can inject secrets when running a container:
 
 ```bash
 docker run --rm --name=connectors -d \
-           -v $PWD/connector.jar:/opt/app/ \  # Add a connector jar to the classpath
-           -e MY_SECRET=secret \              # Set a secret with value
-           -e SECRET_FROM_SHELL \             # Set a secret from the environment
-           --env-file secrets.txt \           # Set secrets from a file
-           camunda/connectors:0.4.2
+           -v $PWD/connector.jar:/opt/app/connector.jar \                      # Add a connector jar to the classpath
+           --network=your-zeebe-network \                                      # Optional: attach to network if Zeebe is isolated with Docker network
+           -e ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS=ip.address.of.zeebe:26500 \  # Specify Zeebe address
+           -e ZEEBE_CLIENT_SECURITY_PLAINTEXT=true \                           # Optional: provide security configs to connect to Zeebe
+           -e MY_SECRET=secret \                                               # Set a secret with value
+           -e SECRET_FROM_SHELL \                                              # Set a secret from the environment
+           --env-file secrets.txt \                                            # Set secrets from a file
+           camunda/connectors:0.5.0
 ```
 
 The secret `MY_SECRET` value is specified directly in the `docker run` call,


### PR DESCRIPTION
## Description

Runtime: updated README to quickstart and test runtime docker image

## Testing done

Did testing with my local setup:

```
docker run --rm --name=connectors -d \
            -v $PWD/connector.jar:/opt/app/connector.jar \
            --network=camunda-platform_camunda-platform \
            -e ZEEBE_CLIENT_BROKER_GATEWAY-ADDRESS=172.19.0.3:26500 \
            -e ZEEBE_CLIENT_SECURITY_PLAINTEXT=true \
            camunda/connectors:0.5.0
```

Runtime starts and receives related job:

```
2023-01-31 15:15:05 2023-01-31 13:15:05.639  INFO 1 --- [           main] i.c.z.s.c.c.OutboundConnectorManager     : Found outbound connectors via classpath that will be registered: [OutboundConnectorConfiguration{name='HTTPJSON', type='io.camunda:http-json:1', inputVariables=[url, method, authentication, headers, queryParameters, connectionTimeoutInSeconds, body], function=io.camunda.connector.http.HttpJsonFunction@58eac00e}]
2023-01-31 15:15:06 2023-01-31 13:15:06.107  INFO 1 --- [           main] i.c.z.s.c.jobhandling.JobWorkerManager   : . Starting Zeebe worker: ZeebeWorkerValue{type='io.camunda:http-json:1', name='HTTPJSON', timeout=null, maxJobsActive=null, requestTimeout=null, pollInterval=null, autoComplete=true, fetchVariables=[url, method, authentication, headers, queryParameters, connectionTimeoutInSeconds, body], enabled=null, methodInfo=null}
2023-01-31 15:15:06 2023-01-31 13:15:06.785  INFO 1 --- [           main] i.c.c.r.ConnectorRuntimeApplication      : Started ConnectorRuntimeApplication in 18.966 seconds (JVM running for 21.862)
2023-01-31 15:15:37 2023-01-31 13:15:37.603  INFO 1 --- [pool-4-thread-1] i.c.c.r.u.outbound.ConnectorJobHandler   : Received job 2251799813686565
```

Related to:

- https://github.com/camunda/team-connectors/issues/325

